### PR TITLE
Added support for mapping java.sql.Time

### DIFF
--- a/codegen/src/main/kotlin/norm/typemapper/DbToKtDefaultTypeMapper.kt
+++ b/codegen/src/main/kotlin/norm/typemapper/DbToKtDefaultTypeMapper.kt
@@ -22,6 +22,7 @@ class DbToKtDefaultTypeMapper {
             "bool" -> Boolean::class
             "timestamptz" -> java.sql.Timestamp::class
             "date" -> java.sql.Date::class
+            "time" -> java.sql.Time::class
             "timestamp" -> java.sql.Timestamp::class
 
             "jsonb" -> PGobject::class


### PR DESCRIPTION
As per issue #63, `time` in SQL query was being mapped to `String`.  
In this PR, I've updated class [`DbToKtDefaultTypeMapper.kt`](https://github.com/medly/norm/compare/master...PatilShreyas:master#diff-6fe1b5bc99682faecb2d107154075152) and added a line to map `time` to `java.sql.Time`.

***Closes***: #63 