### PR TITLE
Added Support for uuid to java.util.UUID Type Mapper

### DIFF
--- a/cli/src/test/kotlin/norm/codegen/CodeGeneratorTest.kt
+++ b/cli/src/test/kotlin/norm/codegen/CodeGeneratorTest.kt
@@ -113,5 +113,11 @@ class CodeGeneratorTest : StringSpec() {
             println(generatedFileContent)
             generatedFileContent shouldBe "/gen/left-joined-nullable-check.expected.txt".readAsResource()
         }
+
+        "should generate kotlin file with sql type uuid mapped to UUID." {
+            val generatedFileContent = codegen(connection, "SELECT * FROM logs", "com.foo", "Foo")
+
+            generatedFileContent shouldBe "/gen/uuid-column-type-generator.expected.txt".readAsResource()
+        }
     }
 }

--- a/cli/src/test/resources/gen/uuid-column-type-generator.expected.txt
+++ b/cli/src/test/resources/gen/uuid-column-type-generator.expected.txt
@@ -1,0 +1,43 @@
+package com.foo
+
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.time.OffsetDateTime
+import java.util.UUID
+import kotlin.String
+import kotlin.Unit
+import norm.ParamSetter
+import norm.Query
+import norm.RowMapper
+
+public class FooParams
+
+public class FooParamSetter : ParamSetter<FooParams> {
+  public override fun map(ps: PreparedStatement, params: FooParams): Unit {
+  }
+}
+
+public data class FooResult(
+  public val id: UUID,
+  public val columnName: String?,
+  public val oldValue: String?,
+  public val newValue: String?,
+  public val capturedAt: OffsetDateTime?
+)
+
+public class FooRowMapper : RowMapper<FooResult> {
+  public override fun map(rs: ResultSet): FooResult = FooResult(
+  id = rs.getObject("id") as java.util.UUID,
+    columnName = rs.getObject("column_name") as kotlin.String?,
+    oldValue = rs.getObject("old_value") as kotlin.String?,
+    newValue = rs.getObject("new_value") as kotlin.String?,
+    capturedAt = rs.getObject("captured_at") as java.time.OffsetDateTime?)
+}
+
+public class FooQuery : Query<FooParams, FooResult> {
+  public override val sql: String = "SELECT * FROM logs"
+
+  public override val mapper: RowMapper<FooResult> = FooRowMapper()
+
+  public override val paramSetter: ParamSetter<FooParams> = FooParamSetter()
+}

--- a/cli/src/test/resources/init_postgres.sql
+++ b/cli/src/test/resources/init_postgres.sql
@@ -25,4 +25,12 @@ CREATE TABLE time_travel_log(
     from_time timestamptz,
     to_time timestamptz,
     duration time
-)
+);
+
+CREATE TABLE logs(
+  id uuid PRIMARY KEY,
+  column_name VARCHAR,
+  old_value VARCHAR,
+  new_value VARCHAR,
+  captured_at TIMESTAMPTZ
+);

--- a/codegen/src/main/kotlin/norm/typemapper/DbToKtDefaultTypeMapper.kt
+++ b/codegen/src/main/kotlin/norm/typemapper/DbToKtDefaultTypeMapper.kt
@@ -30,6 +30,8 @@ class DbToKtDefaultTypeMapper: DbToKtTypeMapper {
 
             "jsonb" -> PGobject::class
 
+            "uuid" -> java.util.UUID::class
+
             "varchar" -> String::class
             "text" -> String::class
             "_varchar" -> String::class


### PR DESCRIPTION
### SUMMARY

- This PR add a new Type Mapper for converting SQL type uuid to java.util.UUID

### Checklist

- [x] Tests for the changes have been added
- [x] It does not introduce a breaking change